### PR TITLE
fix: Popup on the code block with 'Open in browser' redirects to an empty page

### DIFF
--- a/ide/node/settings.json
+++ b/ide/node/settings.json
@@ -9,6 +9,23 @@
   "terminal.integrated.fontWeight": "normal",
   "terminal.integrated.hideOnStartup": "never",
   "workbench.startupEditor": "terminal",
+  "remote.localPortHost": "localhost",
+  "remote.autoForwardPorts": true,
+  "remote.autoForwardPortsSource": "process",
+  "remote.portsAttributes": {
+    "5000": {
+      "label": "Backend Server",
+      "onAutoForward": "openBrowserOnce"
+    },
+    "3000": {
+      "label": "Frontend Server",
+      "onAutoForward": "openBrowserOnce"
+    },
+    "8000": {
+      "label": "Dev Server",
+      "onAutoForward": "openBrowserOnce"
+    }
+  },
   "workbench.colorCustomizations": {
     "sideBar.background": "#131315",
     "sideBarSectionHeader.background": "#131315",

--- a/ide/python/settings.json
+++ b/ide/python/settings.json
@@ -9,6 +9,23 @@
   "terminal.integrated.fontWeight": "normal",
   "terminal.integrated.hideOnStartup": "never",
   "workbench.startupEditor": "terminal",
+  "remote.localPortHost": "localhost",
+  "remote.autoForwardPorts": true,
+  "remote.autoForwardPortsSource": "process",
+  "remote.portsAttributes": {
+    "5000": {
+      "label": "Backend Server",
+      "onAutoForward": "openBrowserOnce"
+    },
+    "3000": {
+      "label": "Frontend Server",
+      "onAutoForward": "openBrowserOnce"
+    },
+    "8000": {
+      "label": "Dev Server",
+      "onAutoForward": "openBrowserOnce"
+    }
+  },
   "workbench.colorCustomizations": {
     "sideBar.background": "#131315",
     "sideBarSectionHeader.background": "#131315",

--- a/workspace-service/templates/flask/app.py
+++ b/workspace-service/templates/flask/app.py
@@ -1,6 +1,6 @@
 # This should be the only entry point of the application
 import os
-from flask import Flask
+from flask import Flask, render_template
 from logging.config import dictConfig
 from models import db
 from flask_migrate import Migrate
@@ -35,6 +35,10 @@ migrate = Migrate(app, db)
 
 # Add Code Here
 
+@app.route('/')
+def home():
+    """Default home route."""
+    return render_template('index.html')
 
 
 # Run the application

--- a/workspace-service/templates/flask/templates/index.html
+++ b/workspace-service/templates/flask/templates/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SuperCoder Flask App</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background-color: #131315;
+            color: #ffffff;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            padding: 20px;
+            box-sizing: border-box;
+        }
+        .container {
+            text-align: center;
+            max-width: 600px;
+        }
+        h1 {
+            color: #7c87e6;
+            margin-bottom: 16px;
+        }
+        p {
+            color: #888;
+            line-height: 1.6;
+        }
+        .status {
+            display: inline-block;
+            background-color: #1a1a1c;
+            padding: 8px 16px;
+            border-radius: 8px;
+            margin-top: 20px;
+        }
+        .status-indicator {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            background-color: #4ade80;
+            border-radius: 50%;
+            margin-right: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Flask Server Running</h1>
+        <p>Your Flask application is running successfully. Start building your backend by adding routes and logic to app.py.</p>
+        <div class="status">
+            <span class="status-indicator"></span>
+            Server is running on port 5000
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
Fixes #54

## Changes
- Add default home route (`/`) to Flask template that renders a landing page
- Add styled index.html template showing server is running
- Configure VS Code remote port forwarding settings for ports 5000, 3000, 8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)