### PR TITLE
Bench-runner tool fixes: timeouts, ignore-list, result caps (ToolPolicy)

### DIFF
--- a/crates/agent/src/agent/config.rs
+++ b/crates/agent/src/agent/config.rs
@@ -52,6 +52,9 @@ pub struct AgentConfig {
     /// before editing it (keyed by `(session_id, turn)`), enabling per-turn undo.
     /// `None` disables checkpoint capture (bench/tests).
     pub checkpoint_dir: Option<PathBuf>,
+    /// Per-binary tool behavior knobs (timeouts, ignore-list, result caps).
+    /// Default = permissive app behavior; `bench-runner` sets `ToolPolicy::bench()`.
+    pub tool_policy: crate::tool::ToolPolicy,
 }
 
 impl AgentConfig {
@@ -71,6 +74,7 @@ impl AgentConfig {
             subagents: None,
             subagent_inheritance: None,
             checkpoint_dir: None,
+            tool_policy: crate::tool::ToolPolicy::default(),
         }
     }
 

--- a/crates/agent/src/agent/loop_.rs
+++ b/crates/agent/src/agent/loop_.rs
@@ -483,6 +483,7 @@ impl AgentLoop {
                 let approval_ref = self.approval_handler.clone();
                 let checkpoint_dir = self.config.checkpoint_dir.clone();
                 let checkpoint_turn = iteration + self.iteration_offset;
+                let tool_policy = self.config.tool_policy.clone();
 
                 join_set.spawn(async move {
                     let result = execute_tool_call_impl(
@@ -497,6 +498,7 @@ impl AgentLoop {
                         approval_ref.as_deref(),
                         checkpoint_dir,
                         checkpoint_turn,
+                        tool_policy,
                     )
                     .await;
                     (idx, tool_call_id, result)
@@ -1037,6 +1039,7 @@ async fn execute_tool_call_impl(
     approval_handler: Option<&dyn ApprovalHandler>,
     checkpoint_dir: Option<std::path::PathBuf>,
     checkpoint_turn: u32,
+    tool_policy: crate::tool::ToolPolicy,
 ) -> ToolResult {
     // Parse arguments first — if this fails, emit a basic ToolStart before the error ToolEnd
     let args: serde_json::Value = match serde_json::from_str(arguments_json) {
@@ -1206,6 +1209,7 @@ async fn execute_tool_call_impl(
         tool_call_id: tool_call_id.to_string(),
         checkpoint_dir,
         checkpoint_turn,
+        policy: tool_policy,
     };
 
     let mut result = match tool.execute(args, &ctx).await {

--- a/crates/agent/src/skills/tool.rs
+++ b/crates/agent/src/skills/tool.rs
@@ -132,6 +132,7 @@ mod tests {
             tool_call_id: "tc_1".into(),
             checkpoint_dir: None,
             checkpoint_turn: 0,
+            policy: crate::tool::ToolPolicy::default(),
         };
         let result = tool
             .execute(json!({"name": "nope"}), &ctx)
@@ -154,6 +155,7 @@ mod tests {
             tool_call_id: "tc_1".into(),
             checkpoint_dir: None,
             checkpoint_turn: 0,
+            policy: crate::tool::ToolPolicy::default(),
         };
         let result = tool
             .execute(json!({"name": "hello"}), &ctx)
@@ -195,6 +197,7 @@ mod tests {
             tool_call_id: "tc_1".into(),
             checkpoint_dir: None,
             checkpoint_turn: 0,
+            policy: crate::tool::ToolPolicy::default(),
         };
         let result = tool
             .execute(json!({"name": "meta"}), &ctx)
@@ -219,6 +222,7 @@ mod tests {
             tool_call_id: "tc_1".into(),
             checkpoint_dir: None,
             checkpoint_turn: 0,
+            policy: crate::tool::ToolPolicy::default(),
         };
         let err = tool.execute(json!({}), &ctx).await.unwrap_err();
         assert!(err.0.contains("Missing"));

--- a/crates/agent/src/subagents/tool.rs
+++ b/crates/agent/src/subagents/tool.rs
@@ -245,6 +245,10 @@ impl Tool for SpawnSubagentTool {
             subagents: None,
             subagent_inheritance: None, // depth-1 enforced
             checkpoint_dir: self.inherit.checkpoint_dir.clone(),
+            // Subagents are only spawned by the desktop app, which runs the permissive
+            // default policy; the headless bench-runner never spawns them. Default keeps
+            // app behavior unchanged.
+            tool_policy: crate::tool::ToolPolicy::default(),
         };
 
         // Child event channel + drain. Per DEC-1 (in docs/subagent-bugs-and-fixes.md),

--- a/crates/agent/src/tool/bash.rs
+++ b/crates/agent/src/tool/bash.rs
@@ -56,10 +56,17 @@ impl Tool for BashTool {
             .and_then(|v| v.as_str())
             .unwrap_or("Running command");
 
-        let timeout_ms = args
+        let mut timeout_ms = args
             .get("timeout")
             .and_then(|v| v.as_u64())
             .unwrap_or(DEFAULT_TIMEOUT_MS);
+
+        // Bench policy clamps the model-supplied timeout to a hard ceiling so a single
+        // runaway command can't burn the whole per-cell wall. No-op under the default
+        // (app) policy, which keeps the timeout fully model-controlled.
+        if let Some(ceiling) = ctx.policy.bash_timeout_ceiling_ms {
+            timeout_ms = timeout_ms.min(ceiling);
+        }
 
         // Emit status event
         let _ = ctx.event_tx.send(AgentEvent::ToolStatus {
@@ -231,6 +238,7 @@ mod tests {
             tool_call_id: "tc_1".into(),
             checkpoint_dir: None,
             checkpoint_turn: 0,
+            policy: crate::tool::ToolPolicy::default(),
         };
 
         let tool = BashTool;
@@ -252,6 +260,34 @@ mod tests {
 
         assert!(result.is_error);
         assert!(result.output.contains("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn test_bench_policy_clamps_timeout() {
+        // Under bench policy the ceiling is 300s. A command that exceeds a *small*
+        // model-supplied timeout still times out (the clamp is a min(), so the
+        // smaller value wins) — this proves the clamp path doesn't break the
+        // existing timeout behavior.
+        let dir = tempdir().unwrap();
+        let tool = BashTool;
+        let ctx = ToolContext::test_context_bench(dir.path());
+
+        let result = tool
+            .execute(
+                json!({ "command": "sleep 10", "description": "sleep", "timeout": 100 }),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_error);
+        assert!(result.output.contains("timed out"));
+    }
+
+    #[test]
+    fn test_bench_policy_ceiling_value() {
+        assert_eq!(crate::tool::ToolPolicy::bench().bash_timeout_ceiling_ms, Some(300_000));
+        assert_eq!(crate::tool::ToolPolicy::default().bash_timeout_ceiling_ms, None);
     }
 
     #[tokio::test]

--- a/crates/agent/src/tool/codebase_graph.rs
+++ b/crates/agent/src/tool/codebase_graph.rs
@@ -7,6 +7,9 @@ use crate::context_engine::ContextEngineApi;
 use crate::error::ToolError;
 use super::{Tool, ToolContext, ToolResult};
 
+/// Max rows rendered per graph section (callers / deps / related) under bench policy.
+const GRAPH_SECTION_CAP: usize = 50;
+
 pub struct CodebaseGraphTool {
     context_engine: Arc<dyn ContextEngineApi>,
 }
@@ -73,7 +76,13 @@ impl Tool for CodebaseGraphTool {
             ));
         }
 
-        let _ = ctx; // ToolContext not needed for graph queries (no working-copy overlay)
+        // Bench policy: cap each rendered section so a high-degree node doesn't dump
+        // hundreds of rows into the context. No-op (unbounded) under the app policy.
+        let section_cap = if ctx.policy.codebase_result_caps {
+            GRAPH_SECTION_CAP
+        } else {
+            usize::MAX
+        };
 
         log::info!(
             "[codebase_graph] query={:?}, function_name={:?}, file_path={:?}, query_type={:?}",
@@ -165,47 +174,44 @@ impl Tool for CodebaseGraphTool {
 
         if show_callers && !callers.is_empty() {
             output.push_str("## Blast Radius (upstream callers)\n\n");
-            for (i, item) in callers.iter().enumerate() {
-                output.push_str(&format!(
-                    "{}. {} ({}, depth: {})\n",
-                    i + 1,
-                    item.name,
-                    item.file_path,
-                    item.depth,
-                ));
-            }
+            render_section(&mut output, &callers, section_cap);
             output.push('\n');
         }
 
         if show_deps && !dependencies.is_empty() {
             output.push_str("## Dependencies (downstream)\n\n");
-            for (i, item) in dependencies.iter().enumerate() {
-                output.push_str(&format!(
-                    "{}. {} ({}, depth: {})\n",
-                    i + 1,
-                    item.name,
-                    item.file_path,
-                    item.depth,
-                ));
-            }
+            render_section(&mut output, &dependencies, section_cap);
             output.push('\n');
         }
 
         if !other.is_empty() && query_type.is_none() {
             output.push_str("## Related\n\n");
-            for (i, item) in other.iter().enumerate() {
-                output.push_str(&format!(
-                    "{}. {} ({}, depth: {})\n",
-                    i + 1,
-                    item.name,
-                    item.file_path,
-                    item.depth,
-                ));
-            }
+            render_section(&mut output, &other, section_cap);
             output.push('\n');
         }
 
         Ok(ToolResult::success(output))
+    }
+}
+
+/// Render up to `cap` graph rows; append a `… and N more` line when the section
+/// is truncated so the model knows results were withheld.
+fn render_section(
+    output: &mut String,
+    items: &[&crate::context_engine::GraphResultItem],
+    cap: usize,
+) {
+    for (i, item) in items.iter().take(cap).enumerate() {
+        output.push_str(&format!(
+            "{}. {} ({}, depth: {})\n",
+            i + 1,
+            item.name,
+            item.file_path,
+            item.depth,
+        ));
+    }
+    if items.len() > cap {
+        output.push_str(&format!("… and {} more\n", items.len() - cap));
     }
 }
 
@@ -403,6 +409,57 @@ mod tests {
 
         assert!(result.is_error);
         assert!(result.output.contains("'query' or 'function_name'"));
+    }
+
+    #[tokio::test]
+    async fn test_bench_policy_caps_section() {
+        let results: Vec<GraphResultItem> = (0..60)
+            .map(|i| GraphResultItem {
+                name: format!("caller_{i}"),
+                file_path: format!("src/f{i}.go"),
+                chunk_id: format!("g{i}"),
+                depth: 1,
+                direction: Some("caller".into()),
+            })
+            .collect();
+        let mock = MockContextEngine::with_graph_results(results);
+        let tool = CodebaseGraphTool::new(Arc::new(mock));
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::test_context_bench(dir.path());
+
+        let result = tool
+            .execute(json!({"function_name": "f", "query_type": "blast_radius"}), &ctx)
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains("caller_49"), "row 50 (index 49) should render");
+        assert!(!result.output.contains("caller_50"), "row 51 must be capped under bench policy");
+        assert!(result.output.contains("… and 10 more"));
+    }
+
+    #[tokio::test]
+    async fn test_default_policy_no_section_cap() {
+        let results: Vec<GraphResultItem> = (0..60)
+            .map(|i| GraphResultItem {
+                name: format!("caller_{i}"),
+                file_path: format!("src/f{i}.go"),
+                chunk_id: format!("g{i}"),
+                depth: 1,
+                direction: Some("caller".into()),
+            })
+            .collect();
+        let mock = MockContextEngine::with_graph_results(results);
+        let tool = CodebaseGraphTool::new(Arc::new(mock));
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::test_context(dir.path());
+
+        let result = tool
+            .execute(json!({"function_name": "f", "query_type": "blast_radius"}), &ctx)
+            .await
+            .unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains("caller_59"), "default policy must render all rows");
+        assert!(!result.output.contains("more"));
     }
 
     #[tokio::test]

--- a/crates/agent/src/tool/codebase_search.rs
+++ b/crates/agent/src/tool/codebase_search.rs
@@ -10,6 +10,24 @@ use crate::context_engine::{ContextEngineApi, SearchResultItem};
 use crate::error::ToolError;
 use super::{Tool, ToolContext, ToolResult};
 
+/// Default result count when the model omits `limit` (bench policy only).
+const DEFAULT_SEARCH_LIMIT: u32 = 20;
+/// Max bytes of chunk content rendered per result (bench policy only).
+const MAX_CHUNK_BYTES: usize = 2048;
+
+/// Truncate a chunk's content to `MAX_CHUNK_BYTES` on a UTF-8 boundary, appending a
+/// marker when clipped. Keeps oversized index payloads from ballooning the context.
+fn cap_chunk_content(content: &str) -> String {
+    if content.len() <= MAX_CHUNK_BYTES {
+        return content.to_string();
+    }
+    let mut end = MAX_CHUNK_BYTES;
+    while !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}\n…[truncated]", &content[..end])
+}
+
 pub struct CodebaseSearchTool {
     context_engine: Arc<dyn ContextEngineApi>,
     /// Canonical repo path the context-engine index was built from (for logging /
@@ -69,7 +87,15 @@ impl Tool for CodebaseSearchTool {
             .ok_or_else(|| ToolError("Missing required parameter: query".into()))?;
 
         let strategy = args.get("strategy").and_then(|v| v.as_str());
-        let limit = args.get("limit").and_then(|v| v.as_u64().map(|n| n as u32));
+        let mut limit = args.get("limit").and_then(|v| v.as_u64().map(|n| n as u32));
+
+        // Bench policy: when the model omits `limit`, default to 20 so the engine
+        // doesn't return a huge result set that balloons the conversation. The model
+        // can still page by raising the existing `limit` param. No-op under app policy.
+        let caps = ctx.policy.codebase_result_caps;
+        if caps && limit.is_none() {
+            limit = Some(DEFAULT_SEARCH_LIMIT);
+        }
 
         log::info!(
             "[codebase_search] query=\"{}\", strategy={:?}, limit={:?}",
@@ -127,6 +153,18 @@ impl Tool for CodebaseSearchTool {
         );
         if let Err(e) = apply_local_overlay(&mut results, &ctx.working_dir).await {
             log::warn!("[codebase_search] local overlay failed, skipping: {e}");
+        }
+
+        // Bench policy: cap result count (defensive — the engine may ignore `limit`)
+        // and cap each chunk's content so oversized payloads don't inflate every
+        // subsequent turn's context. No-op under the default (app) policy.
+        if caps {
+            if let Some(l) = limit {
+                results.truncate(l as usize);
+            }
+            for item in results.iter_mut() {
+                item.content = cap_chunk_content(&item.content);
+            }
         }
 
         let mut output = format!("Found {} results for \"{}\":\n\n", results.len(), query);
@@ -418,6 +456,73 @@ mod tests {
             .unwrap();
 
         assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn test_bench_policy_caps_chunk_content() {
+        let big = "x".repeat(5000);
+        let results = vec![SearchResultItem {
+            chunk_id: "c1".into(),
+            content: big,
+            file_path: "src/big.rs".into(),
+            language: "rust".into(),
+            score: 0.9,
+            source: "vector".into(),
+        }];
+        let mock = MockContextEngine::with_search_results(results);
+        let tool = CodebaseSearchTool::new(Arc::new(mock), PathBuf::from("/repo"));
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::test_context_bench(dir.path());
+
+        let result = tool.execute(json!({"query": "x"}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains("…[truncated]"), "content should be capped under bench policy");
+        // The 5000-char chunk must not appear in full.
+        assert!(!result.output.contains(&"x".repeat(5000)));
+    }
+
+    #[tokio::test]
+    async fn test_bench_policy_truncates_result_count() {
+        let results: Vec<SearchResultItem> = (0..25)
+            .map(|i| SearchResultItem {
+                chunk_id: format!("c{i}"),
+                content: "small".into(),
+                file_path: format!("src/f{i}.rs"),
+                language: "rust".into(),
+                score: 0.5,
+                source: "vector".into(),
+            })
+            .collect();
+        let mock = MockContextEngine::with_search_results(results);
+        let tool = CodebaseSearchTool::new(Arc::new(mock), PathBuf::from("/repo"));
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::test_context_bench(dir.path());
+
+        let result = tool.execute(json!({"query": "x"}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains("Found 20 results"), "should cap to default limit 20 under bench policy");
+    }
+
+    #[tokio::test]
+    async fn test_default_policy_no_caps() {
+        let big = "y".repeat(5000);
+        let results = vec![SearchResultItem {
+            chunk_id: "c1".into(),
+            content: big.clone(),
+            file_path: "src/big.rs".into(),
+            language: "rust".into(),
+            score: 0.9,
+            source: "vector".into(),
+        }];
+        let mock = MockContextEngine::with_search_results(results);
+        let tool = CodebaseSearchTool::new(Arc::new(mock), PathBuf::from("/repo"));
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::test_context(dir.path());
+
+        let result = tool.execute(json!({"query": "y"}), &ctx).await.unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains(&big), "default policy must not cap content");
+        assert!(!result.output.contains("…[truncated]"));
     }
 
     #[tokio::test]

--- a/crates/agent/src/tool/glob.rs
+++ b/crates/agent/src/tool/glob.rs
@@ -44,19 +44,47 @@ impl Tool for GlobTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| ToolError("Missing required parameter: pattern".into()))?;
 
-        let base_path = match args.get("path").and_then(|v| v.as_str()) {
+        let path_arg = args.get("path").and_then(|v| v.as_str());
+        let base_path = match path_arg {
             Some(p) => resolve_path(&ctx.working_dir, p),
             None => ctx.working_dir.clone(),
         };
 
-        let pattern = pattern.to_string();
+        // Bench policy: skip build/vendor/coverage dirs at walk time (prevents
+        // descending into node_modules, the latency source) unless the model
+        // explicitly targets one via `pattern` or `path`. No-op under app policy.
+        let ignore_dirs: Vec<String> = if ctx.policy.search_default_ignores {
+            super::DEFAULT_IGNORE_DIRS
+                .iter()
+                .filter(|d| !explicitly_targeted(d, path_arg, pattern))
+                .map(|d| d.to_string())
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let ignore_min_assets = ctx.policy.search_default_ignores;
+
+        let pattern_owned = pattern.to_string();
         let base = base_path.clone();
 
-        let result = tokio::task::spawn_blocking(move || {
-            glob_search(&base, &pattern)
-        })
-        .await
-        .map_err(|e| ToolError(format!("Glob task failed: {e}")))?;
+        let handle = tokio::task::spawn_blocking(move || {
+            glob_search(&base, &pattern_owned, ignore_dirs, ignore_min_assets)
+        });
+
+        // Bench policy: bound the walk with a wall timeout. The blocking thread runs
+        // to completion on its own; we just stop waiting and discard its result.
+        let result = match ctx.policy.search_timeout_ms {
+            Some(ms) => match tokio::time::timeout(std::time::Duration::from_millis(ms), handle).await {
+                Ok(join) => join.map_err(|e| ToolError(format!("Glob task failed: {e}")))?,
+                Err(_) => {
+                    return Ok(ToolResult::error(format!(
+                        "glob timed out after {}s — narrow the pattern or restrict `path`.",
+                        ms / 1000
+                    )));
+                }
+            },
+            None => handle.await.map_err(|e| ToolError(format!("Glob task failed: {e}")))?,
+        };
 
         match result {
             Ok(output) => Ok(ToolResult::success(output)),
@@ -65,7 +93,26 @@ impl Tool for GlobTool {
     }
 }
 
-fn glob_search(base_path: &std::path::Path, pattern: &str) -> Result<String, String> {
+/// True if the model explicitly referenced `dir` in the `path` or the glob `pattern`,
+/// meaning the default ignore-list should NOT exclude it (the override mechanism).
+fn explicitly_targeted(dir: &str, path_arg: Option<&str>, pattern: &str) -> bool {
+    pattern.contains(dir) || path_arg.map(|p| p.contains(dir)).unwrap_or(false)
+}
+
+/// True if `name` is a minified asset excluded by the default ignore-glob list.
+fn is_min_asset(name: &str) -> bool {
+    super::DEFAULT_IGNORE_GLOBS.iter().any(|g| {
+        // DEFAULT_IGNORE_GLOBS are of the form "*.ext" — match by suffix.
+        g.strip_prefix('*').map(|suf| name.ends_with(suf)).unwrap_or(false)
+    })
+}
+
+fn glob_search(
+    base_path: &std::path::Path,
+    pattern: &str,
+    ignore_dirs: Vec<String>,
+    ignore_min_assets: bool,
+) -> Result<String, String> {
     let matcher = globset::GlobBuilder::new(pattern)
         .literal_separator(true) // * doesn't match /, only ** does
         .build()
@@ -75,6 +122,20 @@ fn glob_search(base_path: &std::path::Path, pattern: &str) -> Result<String, Str
     let walker = ignore::WalkBuilder::new(base_path)
         .standard_filters(true)
         .hidden(false) // don't skip hidden files (let .gitignore handle it)
+        .filter_entry(move |entry| {
+            let is_dir = entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false);
+            if let Some(name) = entry.file_name().to_str() {
+                // Prune blocked directories (stops descent — the latency fix).
+                if is_dir && ignore_dirs.iter().any(|d| d == name) {
+                    return false;
+                }
+                // Prune minified assets.
+                if !is_dir && ignore_min_assets && is_min_asset(name) {
+                    return false;
+                }
+            }
+            true
+        })
         .build();
 
     let mut entries: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
@@ -243,6 +304,70 @@ mod tests {
 
         assert!(!result.is_error);
         assert!(result.output.contains("Showing 100 of 110 results"));
+    }
+
+    #[tokio::test]
+    async fn test_glob_bench_policy_skips_node_modules() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("node_modules/pkg/index.js"), "x").unwrap();
+        fs::write(dir.path().join("src/app.js"), "x").unwrap();
+
+        let tool = GlobTool;
+        let ctx = ToolContext::test_context_bench(dir.path());
+        let result = tool.execute(json!({ "pattern": "**/*.js" }), &ctx).await.unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("app.js"));
+        assert!(!result.output.contains("node_modules"), "must prune node_modules under bench policy");
+    }
+
+    #[tokio::test]
+    async fn test_glob_default_policy_includes_node_modules() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        fs::write(dir.path().join("node_modules/pkg/index.js"), "x").unwrap();
+
+        let tool = GlobTool;
+        let ctx = ToolContext::test_context(dir.path());
+        let result = tool.execute(json!({ "pattern": "**/*.js" }), &ctx).await.unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("node_modules"), "default policy must not prune node_modules");
+    }
+
+    #[tokio::test]
+    async fn test_glob_bench_policy_explicit_override() {
+        let dir = tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        fs::write(dir.path().join("node_modules/pkg/index.js"), "x").unwrap();
+
+        let tool = GlobTool;
+        let ctx = ToolContext::test_context_bench(dir.path());
+        // Pattern explicitly names node_modules → override the prune.
+        let result = tool
+            .execute(json!({ "pattern": "node_modules/**/*.js" }), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("node_modules"), "explicit pattern must override the prune");
+    }
+
+    #[tokio::test]
+    async fn test_glob_bench_policy_skips_min_assets() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join("app.js"), "x").unwrap();
+        fs::write(dir.path().join("app.min.js"), "x").unwrap();
+
+        let tool = GlobTool;
+        let ctx = ToolContext::test_context_bench(dir.path());
+        let result = tool.execute(json!({ "pattern": "**/*.js" }), &ctx).await.unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("app.js"));
+        assert!(!result.output.contains("app.min.js"), "must skip minified assets under bench policy");
     }
 
     #[tokio::test]

--- a/crates/agent/src/tool/grep.rs
+++ b/crates/agent/src/tool/grep.rs
@@ -56,12 +56,48 @@ impl Tool for GrepTool {
         };
 
         let include = args.get("include").and_then(|v| v.as_str());
+        let path_arg = args.get("path").and_then(|v| v.as_str());
+
+        // Bench policy: skip build/vendor/coverage dirs unless the model explicitly
+        // targets one via `path` or `include` (the override — no new param). No-op
+        // under the default (app) policy.
+        let ignore_dirs: Vec<&str> = if ctx.policy.search_default_ignores {
+            super::DEFAULT_IGNORE_DIRS
+                .iter()
+                .copied()
+                .filter(|d| !explicitly_targeted(d, path_arg, include))
+                .collect()
+        } else {
+            Vec::new()
+        };
+        let ignore_globs: &[&str] = if ctx.policy.search_default_ignores {
+            super::DEFAULT_IGNORE_GLOBS
+        } else {
+            &[]
+        };
 
         // Try rg first, fall back to grep
-        let output = if rg_available() {
-            run_rg(pattern, &search_path, include, &ctx.working_dir).await
-        } else {
-            run_grep(pattern, &search_path, include, &ctx.working_dir).await
+        let run = async {
+            if rg_available() {
+                run_rg(pattern, &search_path, include, &ctx.working_dir, &ignore_dirs, ignore_globs).await
+            } else {
+                run_grep(pattern, &search_path, include, &ctx.working_dir, &ignore_dirs, ignore_globs).await
+            }
+        };
+
+        // Bench policy: bound the search with a wall timeout so a pathological pattern
+        // on a huge tree can't hang the agent. No-op under the default (app) policy.
+        let output = match ctx.policy.search_timeout_ms {
+            Some(ms) => match tokio::time::timeout(std::time::Duration::from_millis(ms), run).await {
+                Ok(o) => o,
+                Err(_) => {
+                    return Ok(ToolResult::error(format!(
+                        "grep timed out after {}s — narrow the pattern or restrict `path`.",
+                        ms / 1000
+                    )));
+                }
+            },
+            None => run.await,
         };
 
         match output {
@@ -91,6 +127,13 @@ impl Tool for GrepTool {
     }
 }
 
+/// True if the model explicitly referenced `dir` in the `path` or `include` glob,
+/// meaning the default ignore-list should NOT exclude it (the override mechanism).
+fn explicitly_targeted(dir: &str, path_arg: Option<&str>, include: Option<&str>) -> bool {
+    path_arg.map(|p| p.contains(dir)).unwrap_or(false)
+        || include.map(|i| i.contains(dir)).unwrap_or(false)
+}
+
 fn rg_available() -> bool {
     let mut cmd = std::process::Command::new("rg");
     cmd.arg("--version");
@@ -103,6 +146,8 @@ async fn run_rg(
     search_path: &std::path::Path,
     include: Option<&str>,
     working_dir: &std::path::Path,
+    ignore_dirs: &[&str],
+    ignore_globs: &[&str],
 ) -> std::io::Result<std::process::Output> {
     let mut cmd = Command::new("rg");
     cmd.arg("-n")
@@ -112,6 +157,14 @@ async fn run_rg(
 
     if let Some(glob) = include {
         cmd.arg("--glob").arg(glob);
+    }
+
+    // Default ignore-list (bench policy): exclude build/vendor/coverage dirs + minified assets.
+    for dir in ignore_dirs {
+        cmd.arg("--glob").arg(format!("!**/{dir}/**"));
+    }
+    for glob in ignore_globs {
+        cmd.arg("--glob").arg(format!("!{glob}"));
     }
 
     cmd.arg(pattern)
@@ -130,6 +183,8 @@ async fn run_grep(
     search_path: &std::path::Path,
     include: Option<&str>,
     working_dir: &std::path::Path,
+    ignore_dirs: &[&str],
+    ignore_globs: &[&str],
 ) -> std::io::Result<std::process::Output> {
     let mut cmd = Command::new("grep");
     cmd.arg("-r")     // recursive
@@ -139,6 +194,15 @@ async fn run_grep(
 
     if let Some(glob) = include {
         cmd.arg("--include").arg(glob);
+    }
+
+    // Default ignore-list (bench policy): grep has no .gitignore awareness, so this
+    // is the only thing keeping build/vendor dirs out of the fallback path.
+    for dir in ignore_dirs {
+        cmd.arg(format!("--exclude-dir={dir}"));
+    }
+    for glob in ignore_globs {
+        cmd.arg(format!("--exclude={glob}"));
     }
 
     cmd.arg(pattern)
@@ -299,6 +363,63 @@ mod tests {
         assert!(result.is_error);
         assert!(result.output.contains("Grep error") || result.output.contains("Invalid")
             || result.output.contains("Unmatched"));
+    }
+
+    #[tokio::test]
+    async fn test_grep_bench_policy_skips_node_modules() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        std::fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("node_modules/pkg/index.js"), "needle here\n").unwrap();
+        fs::write(dir.path().join("src/app.js"), "needle here\n").unwrap();
+
+        let tool = GrepTool;
+        let ctx = ToolContext::test_context_bench(dir.path());
+        let result = tool.execute(json!({ "pattern": "needle" }), &ctx).await.unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("src/app.js"), "should find src match");
+        assert!(!result.output.contains("node_modules"), "must skip node_modules under bench policy");
+    }
+
+    #[tokio::test]
+    async fn test_grep_default_policy_searches_node_modules() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        fs::write(dir.path().join("node_modules/pkg/index.js"), "needle here\n").unwrap();
+
+        let tool = GrepTool;
+        // Default (app) policy + no .git → no ignore-list, node_modules IS searched.
+        let ctx = ToolContext::test_context(dir.path());
+        let result = tool.execute(json!({ "pattern": "needle" }), &ctx).await.unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("node_modules"), "default policy must not exclude node_modules");
+    }
+
+    #[tokio::test]
+    async fn test_grep_bench_policy_explicit_override() {
+        let dir = tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        fs::write(dir.path().join("node_modules/pkg/index.js"), "needle here\n").unwrap();
+
+        let tool = GrepTool;
+        let ctx = ToolContext::test_context_bench(dir.path());
+        // Explicitly target node_modules via path → override the ignore-list.
+        let result = tool
+            .execute(json!({ "pattern": "needle", "path": "node_modules" }), &ctx)
+            .await
+            .unwrap();
+
+        assert!(!result.is_error);
+        assert!(result.output.contains("node_modules"), "explicit path must override the ignore-list");
+    }
+
+    #[test]
+    fn test_explicitly_targeted() {
+        assert!(explicitly_targeted("node_modules", Some("node_modules"), None));
+        assert!(explicitly_targeted("target", None, Some("target/**/*.rs")));
+        assert!(!explicitly_targeted("node_modules", Some("src"), Some("*.rs")));
     }
 
     #[test]

--- a/crates/agent/src/tool/mod.rs
+++ b/crates/agent/src/tool/mod.rs
@@ -66,6 +66,66 @@ impl ToolResult {
     }
 }
 
+/// Directories the bench `ToolPolicy` excludes from grep/glob unless the model
+/// explicitly targets them. Build/vendor/coverage output that pollutes results
+/// and inflates search latency on large repos (monorepos, java target/site).
+pub const DEFAULT_IGNORE_DIRS: &[&str] = &[
+    ".git",
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "__pycache__",
+    ".next",
+    "vendor",
+    "coverage",
+];
+
+/// Minified-asset globs the bench `ToolPolicy` excludes from grep/glob.
+pub const DEFAULT_IGNORE_GLOBS: &[&str] = &["*.min.js", "*.min.css"];
+
+/// Per-binary behavior knobs for tool execution. The default is **permissive**
+/// (byte-identical to the desktop app's historical behavior); `ToolPolicy::bench()`
+/// is the strict variant the headless `bench-runner` opts into so the eval harness
+/// is robust to runaway searches and oversized result payloads. Gating these behind
+/// a policy keeps the shipped app agent unchanged.
+#[derive(Debug, Clone)]
+pub struct ToolPolicy {
+    /// Clamp ceiling (ms) for the bash `timeout` arg. `None` = no ceiling (app default).
+    pub bash_timeout_ceiling_ms: Option<u64>,
+    /// Internal wall timeout (ms) for grep/glob. `None` = no wall (app default).
+    pub search_timeout_ms: Option<u64>,
+    /// Skip the default ignore-dir list in grep/glob. `false` = no extra ignores (app default).
+    pub search_default_ignores: bool,
+    /// Apply codebase_search/graph result + content caps. `false` = no caps (app default).
+    pub codebase_result_caps: bool,
+}
+
+impl Default for ToolPolicy {
+    /// Permissive — preserves the historical desktop-app behavior exactly.
+    fn default() -> Self {
+        Self {
+            bash_timeout_ceiling_ms: None,
+            search_timeout_ms: None,
+            search_default_ignores: false,
+            codebase_result_caps: false,
+        }
+    }
+}
+
+impl ToolPolicy {
+    /// Strict policy for the eval harness: bash clamped to 300s, grep/glob walled at
+    /// 60s and skipping build/vendor dirs, codebase_* results capped.
+    pub fn bench() -> Self {
+        Self {
+            bash_timeout_ceiling_ms: Some(300_000),
+            search_timeout_ms: Some(60_000),
+            search_default_ignores: true,
+            codebase_result_caps: true,
+        }
+    }
+}
+
 /// Context passed to every tool execution.
 pub struct ToolContext {
     pub working_dir: PathBuf,
@@ -79,6 +139,9 @@ pub struct ToolContext {
     pub checkpoint_dir: Option<PathBuf>,
     /// Current turn number, used as the checkpoint key alongside `session_id`.
     pub checkpoint_turn: u32,
+    /// Per-binary behavior knobs (timeouts, ignore-list, result caps). Default =
+    /// permissive app behavior; `bench-runner` sets `ToolPolicy::bench()`.
+    pub policy: ToolPolicy,
 }
 
 impl ToolContext {
@@ -108,6 +171,15 @@ impl ToolContext {
             tool_call_id: "tc_1".into(),
             checkpoint_dir: None,
             checkpoint_turn: 0,
+            policy: ToolPolicy::default(),
+        }
+    }
+
+    /// Like `test_context` but with the strict `ToolPolicy::bench()` applied.
+    pub(crate) fn test_context_bench(dir: &std::path::Path) -> Self {
+        Self {
+            policy: ToolPolicy::bench(),
+            ..Self::test_context(dir)
         }
     }
 }

--- a/crates/agent/src/tool/write.rs
+++ b/crates/agent/src/tool/write.rs
@@ -96,6 +96,7 @@ mod tests {
             tool_call_id: "tc_1".into(),
             checkpoint_dir: Some(ckpt.path().to_path_buf()),
             checkpoint_turn: 1,
+            policy: crate::tool::ToolPolicy::default(),
         };
 
         // write overwrites the file (backs up "original\n") ...

--- a/crates/agent/tests/integration.rs
+++ b/crates/agent/tests/integration.rs
@@ -155,6 +155,7 @@ fn make_config(api_key: &str, working_dir: PathBuf) -> AgentConfig {
         subagents: None,
         subagent_inheritance: None,
         checkpoint_dir: None,
+        tool_policy: Default::default(),
     }
 }
 

--- a/crates/bench-runner/src/main.rs
+++ b/crates/bench-runner/src/main.rs
@@ -206,6 +206,10 @@ async fn run(cli: &Cli, spec: &TaskSpec) -> RunResult {
     let mut config = AgentConfig::new(llm, spec.working_dir.clone());
     config.mode = ToolMode::Coding;
     config.max_iterations = spec.max_iterations;
+    // Strict tool policy is part of the frozen harness identity: bash timeout ceiling,
+    // grep/glob ignore-list + wall timeout, codebase_* result caps. Always on (the app
+    // keeps the permissive default). See ToolPolicy::bench().
+    config.tool_policy = agent::tool::ToolPolicy::bench();
     // Everything else (system_prompt, checkpoint_dir, skills, subagents, …) stays at the
     // AgentConfig::new defaults of None — headless.
 


### PR DESCRIPTION
## Summary

Three agent-tooling fixes for the eval harness, all scoped to **bench-runner only** via a new `ToolPolicy` on `ToolContext`. The default policy is **byte-identical to today's desktop-app behavior** (no product risk); bench-runner opts into the strict variant. **No tool-schema or prompt changes** — tool definitions stay identical to v0.1.4.

Targets the pilot's three measured issues (runaway searches, result pollution, oversized context payloads) ahead of the 173×ON/OFF grid.

## The three fixes (bench policy only)

1. **Per-tool timeouts** — `bash` clamps the model `timeout` to `min(arg, 300s)`; `grep`/`glob` get a 60s wall timeout that returns an adaptable error; `codebase_*` keep their existing 30s HTTP timeout.
2. **Default ignore-list** — `grep` (rg `--glob '!'` + grep `--exclude-dir`) and `glob` (walk-time `filter_entry`, so it never descends) skip `.git, node_modules, target, dist, build, __pycache__, .next, vendor, coverage` + `*.min.js`/`*.min.css`. Overridable, no new param: if the model explicitly names a blocked dir in `path`/`include`/`pattern`, it's searched anyway.
3. **Result caps** — `codebase_search` defaults `limit=20` and caps each chunk's content to 2 KB (`…[truncated]`); `codebase_graph` renders ≤50 rows per section (`… and N more`).

## Architecture

`ToolPolicy` carried on `ToolContext`, threaded from `AgentConfig` through the agent loop. `ToolPolicy::default()` = permissive (app); `ToolPolicy::bench()` = strict. bench-runner sets `bench()` unconditionally (frozen harness identity). Subagents + desktop app keep the default.

## Testing

- **Unit:** 14 new tests — each fix has a bench-policy test **and** a default-policy test proving the app path is unchanged. Full agent lib suite: **442 passed**. `cargo check --workspace --all-targets` clean.
- **Live scale test** (real compiled `glob`/`grep`, 50k-file `node_modules`):
  | policy | glob `**/*.js` | grep | node_modules in results | src found | min.js |
  |--------|------|------|----|----|----|
  | default (app) | 752 ms | 1049 ms | yes (98–99) | yes | included |
  | **bench** | **0 ms** | **10 ms** | **none** | **yes** | **excluded** |
  
  ~100× faster, node_modules fully excluded, real source still found — this is the regression that caused the 18-min monorepo hang.

## Invariants

- **Zero new dependencies** (no Cargo.toml/Cargo.lock changes) → static-musl R1 invariant structurally untouched; CI `bench-runner-musl` is the gate.
- **No schema/prompt changes** → treatment unchanged vs v0.1.4.